### PR TITLE
Add channel management commands and cleanup functionality

### DIFF
--- a/commands/add_channel.py
+++ b/commands/add_channel.py
@@ -1,0 +1,11 @@
+import discord
+from utils.sql import sql
+
+def group_add_channel(group, db, bot, debug=False):
+    # Add a new channel to be managed by bot
+    @group.command(name="add", description="Adds a new auto creating channel")
+    async def add(inter: discord.Interaction, channel: discord.abc.GuildChannel) -> None:
+        result = sql.add_channel(db, "channel_static", channel.id, channel.name, channel.guild.id, debug=debug)
+        await inter.response.send_message(f"Channel '{channel.name}' added to auto creating channels.")
+
+    return group

--- a/commands/remove_channel.py
+++ b/commands/remove_channel.py
@@ -1,0 +1,11 @@
+import discord
+from utils.sql import sql
+
+def group_remove_channel(group, db, bot, debug=False):
+    # Remove a channel from being managed by bot
+    @group.command(name="remove", description="Removes an auto creating channel")
+    async def remove(inter: discord.Interaction, channel: discord.abc.GuildChannel) -> None:
+        sql.delete_channel(db, "channel_static", channel.id, debug=debug)
+        await inter.response.send_message(f"Channel '{channel.name}' removed from auto creating channels.")
+
+    return group

--- a/events/bot_on_ready.py
+++ b/events/bot_on_ready.py
@@ -1,5 +1,5 @@
 from py_compile import main
-from scripts import db_fix
+from scripts import db_fix, cleanup_channels
 
 
 def main_commands_sync(bot, db):
@@ -11,3 +11,6 @@ def main_commands_sync(bot, db):
         print("Bot is ready and commands are synced.")
 
         db_fix.fix_db_channel(db, bot)
+        await cleanup_channels.cleanup_static_channels(db, bot)
+        await cleanup_channels.cleanup_dynamic_channels(db, bot)
+        print("Database channels cleaned up.")

--- a/main.py
+++ b/main.py
@@ -29,6 +29,8 @@ def main():
     from commands import create_channel
     from commands import delete_channel
     from commands import list_channels
+    from commands import add_channel
+    from commands import remove_channel 
 
     # ----------------- CREATE COMMAND GROUPS --------------------
     group = discord.app_commands.Group(
@@ -39,6 +41,8 @@ def main():
     group = create_channel.group_create(bot, group, db, debug=debug)
     group = delete_channel.group_delete(group, db, debug=debug)
     group = list_channels.group_list(group, db, bot, debug=debug)
+    group = add_channel.group_add_channel(group, db, bot, debug=debug)
+    group = remove_channel.group_remove_channel(group, db, bot, debug=debug)
 
     bot.tree.add_command(group)
 

--- a/scripts/cleanup_channels.py
+++ b/scripts/cleanup_channels.py
@@ -1,0 +1,27 @@
+from utils.sql import sql
+from utils.delete_channels import Delete_Static_Channels, Delete_Dynamic_Channels
+
+async def cleanup_static_channels(db, bot, debug=False):
+    """Cleans up static channels that no longer exist in the database."""
+    channels = sql.list_channel_id(db, "channel_static", debug=debug)
+    for channel in channels:
+        channel_id = channel
+        if bot.get_channel(channel_id) is None:
+            if debug:
+                print(f"Cleaning up static channel ID: {channel_id}")
+            sql.delete_channel(db, "channel_static", channel_id, debug=debug)
+
+async def cleanup_dynamic_channels(db, bot, debug=False):
+    """Cleans up dynamic channels that no longer exist in the database."""
+    channels = sql.list_channel_id(db, "channel_dynamic", debug=debug)
+    for channel in channels:
+        channel_id = channel
+        if bot.get_channel(channel_id) is None:
+            if debug:
+                print(f"Cleaning up dynamic channel ID: {channel_id}")
+            sql.delete_channel(db, "channel_dynamic", channel_id, debug=debug)
+        elif bot.get_channel(channel_id).members == []:
+            if debug:
+                print(f"Cleaning up empty dynamic channel ID: {channel_id}")
+            sql.delete_channel(db, "channel_dynamic", channel_id, debug=debug)
+            await Delete_Dynamic_Channels(bot.get_channel(channel_id), db, debug=debug)


### PR DESCRIPTION
- Implemented `add_channel` and `remove_channel` commands for managing auto-creating channels.
- Enhanced `on_ready` event to include cleanup of static and dynamic channels.
- Added cleanup functions for static and dynamic channels to remove non-existent channels from the database.
- Closes #27 and #33